### PR TITLE
Release for v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.5](https://github.com/orangekame3/tftarget/compare/v0.0.4...v0.0.5) - 2023-03-09
+- Bump golang.org/x/text from 0.3.3 to 0.3.8 by @dependabot in https://github.com/orangekame3/tftarget/pull/6
+
 ## [v0.0.4](https://github.com/orangekame3/tftarget/compare/v0.0.3...v0.0.4) - 2023-03-09
 
 ## [v0.0.3](https://github.com/orangekame3/tftarget/compare/v0.0.2...v0.0.3) - 2023-03-09


### PR DESCRIPTION
This pull request is for the next release as v0.0.5 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.5 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.4" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Bump golang.org/x/text from 0.3.3 to 0.3.8 by @dependabot in https://github.com/orangekame3/tftarget/pull/6

## New Contributors
* @dependabot made their first contribution in https://github.com/orangekame3/tftarget/pull/6

**Full Changelog**: https://github.com/orangekame3/tftarget/compare/v0.0.4...v0.0.5